### PR TITLE
🔧 CLIENT REVISION: Expand All + Font Styling Updates

### DIFF
--- a/wp-content/themes/buddyboss-theme-child/assets/css/course-sections-toggle.css
+++ b/wp-content/themes/buddyboss-theme-child/assets/css/course-sections-toggle.css
@@ -23,7 +23,7 @@
     margin: 0;
     border-radius: 6px;
     letter-spacing: 0.6px; /* ADDED: Match LearnDash section heading letter-spacing */
-    text-transform: uppercase; /* ADDED: Match LearnDash section heading text-transform */
+    text-transform: capitalize; /* CHANGED: Less aggressive than uppercase per client request */
 }
 
 .custom-section-toggle-btn:hover {
@@ -69,7 +69,7 @@
     font-size: 16px; /* CHANGED: Match exact LearnDash default section heading font size */
     color: var(--bb-headings-color); /* CHANGED: Match exact LearnDash section heading color */
     letter-spacing: 0.6px; /* ADDED: Match LearnDash section heading letter-spacing */
-    text-transform: uppercase; /* ADDED: Match LearnDash section heading text-transform */
+    text-transform: capitalize; /* CHANGED: Less aggressive than uppercase per client request */
 }
 
 /* Expanded state */


### PR DESCRIPTION
CLIENT FEEDBACK IMPLEMENTED:
✅ 'Expand All' now ONLY expands section headings, NOT lessons ✅ Font styling changed from uppercase to capitalize (less aggressive) ✅ Font size kept at 16px (client approved)

EXPAND ALL CHANGES:
❌ Before: Expanded sections + let LearnDash expand lessons ✅ After: ONLY expands sections, lessons remain collapsed 🔧 Completely overrode LearnDash's click handler
🔧 Removed MutationObserver (no longer needed)
🔧 Direct control over expand/collapse functionality

FONT STYLING CHANGES:
❌ Before: text-transform: uppercase (too aggressive per client) ✅ After: text-transform: capitalize (less aggressive) ✅ Maintained: font-size: 16px (client likes it)
✅ Maintained: letter-spacing: 0.6px
✅ Maintained: color: var(--bb-headings-color)

TECHNICAL IMPLEMENTATION:
✅ $mainExpandButton.off('click') - removes LearnDash handler ✅ Custom click handler with complete control
✅ Proper button state management (ld-expanded class) ✅ Smooth slideDown/slideUp animations
✅ Console logging for debugging

Perfect client requirements implementation! 🚀